### PR TITLE
Add executable examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 
-# expect
-    import "github.com/leemcloughlin/expect"
 
+# expect
+`import "github.com/leemcloughlin/expect"`
+
+* [Overview](#pkg-overview)
+* [Index](#pkg-index)
+* [Examples](#pkg-examples)
+* [Subdirectories](#pkg-subdirectories)
+
+## <a name="pkg-overview">Overview</a>
 Expect is pure Go (golang) version of the terminal interaction package Expect
 common on many Linux systems
 
@@ -31,7 +38,37 @@ This package has only been tested on Linux
 
 
 
-## Constants
+## <a name="pkg-index">Index</a>
+* [Constants](#pkg-constants)
+* [Variables](#pkg-variables)
+* [type Expect](#Expect)
+  * [func NewExpect(prog string, arg ...string) (*Expect, error)](#NewExpect)
+  * [func NewExpectProc(ctx context.Context, prog string, arg ...string) (*Expect, *os.Process, error)](#NewExpectProc)
+  * [func Spawn(prog string, arg ...string) (*Expect, error)](#Spawn)
+  * [func (exp *Expect) BufStr() string](#Expect.BufStr)
+  * [func (exp *Expect) Clear()](#Expect.Clear)
+  * [func (exp *Expect) Expect(reOrStrs ...interface{}) (int, []byte, error)](#Expect.Expect)
+  * [func (exp *Expect) Expecti(reOrStrs ...interface{}) int](#Expect.Expecti)
+  * [func (exp *Expect) Expectp(reOrStrs ...interface{}) int](#Expect.Expectp)
+  * [func (exp *Expect) Kill()](#Expect.Kill)
+  * [func (exp *Expect) LogUser(on bool)](#Expect.LogUser)
+  * [func (exp *Expect) Send(s string) (int, error)](#Expect.Send)
+  * [func (exp *Expect) SendL(lines ...string) error](#Expect.SendL)
+  * [func (exp *Expect) SendSlow(delay time.Duration, s string) (int, error)](#Expect.SendSlow)
+  * [func (exp *Expect) SetCmdOut(cmdOut io.Writer)](#Expect.SetCmdOut)
+  * [func (exp *Expect) SetTimeout(timeout time.Duration)](#Expect.SetTimeout)
+  * [func (exp *Expect) SetTimeoutSecs(timeout int)](#Expect.SetTimeoutSecs)
+* [type ExpectWaitResult](#ExpectWaitResult)
+
+#### <a name="pkg-examples">Examples</a>
+* [Expect](#example_Expect)
+* [Expect (OwnEcho)](#example_Expect_ownEcho)
+
+#### <a name="pkg-files">Package files</a>
+[expect.go](/src/github.com/leemcloughlin/expect/expect.go) 
+
+
+## <a name="pkg-constants">Constants</a>
 ``` go
 const (
     // NotFound is returned by Expect for non-matching non-errors (include EOF)
@@ -45,7 +82,7 @@ const (
 )
 ```
 
-## Variables
+## <a name="pkg-variables">Variables</a>
 ``` go
 var (
     ETimedOut           = errors.New("TimedOut")
@@ -67,12 +104,10 @@ var (
 ```
 
 
-## type Expect
+
+## <a name="Expect">type</a> [Expect](/src/target/expect.go?s=2105:2883#L85)
 ``` go
 type Expect struct {
-    // *os.File is an anonymous field for the pty connected to the command.
-    // This allows you to treat *Expect as a *os.File
-    *os.File
 
     // Expect reads into here. On a successful match all data up the end of the
     // match is deleted shrinking the buffer.
@@ -81,6 +116,9 @@ type Expect struct {
 
     // On EOF being read from Cmd this is set (and ExpectReader is ended)
     Eof bool
+
+    // Result is filled in asynchronously after the cmd exits
+    Result ExpectWaitResult
     // contains filtered or unexported fields
 }
 ```
@@ -90,19 +128,32 @@ type Expect struct {
 
 
 
-
-
-### func NewExpect
+### <a name="NewExpect">func</a> [NewExpect](/src/target/expect.go?s=3431:3490#L131)
 ``` go
 func NewExpect(prog string, arg ...string) (*Expect, error)
 ```
 NewExpect starts prog, passing any given args, in its own pty.
 Note that in order to be non-blocking while reading from the pty this sets
 the non-blocking flag and looks for EAGAIN on reads failing.  This has only
-been tested on Linux systems
+been tested on Linux systems.
+On prog exiting or being killed Result is filled in shortly after.
 
 
-### func Spawn
+### <a name="NewExpectProc">func</a> [NewExpectProc](/src/target/expect.go?s=4081:4178#L143)
+``` go
+func NewExpectProc(ctx context.Context, prog string, arg ...string) (*Expect, *os.Process, error)
+```
+NewExpectProc is similar to NewExpect except the created cmd is returned.
+It is expected that the cmd will exit normally otherwise it is left to
+the caller to kill it. This can be achieved by canceling the context @ctx.
+In the event of an error starting the cmd it will be killed but not reaped.
+However the cmd ends it is important that the caller reap the process
+by calling cmd.Process.Wait() otherwise it can use up a process slot in
+the operating system.
+Note that Result is not filled in.
+
+
+### <a name="Spawn">func</a> [Spawn](/src/target/expect.go?s=11281:11336#L402)
 ``` go
 func Spawn(prog string, arg ...string) (*Expect, error)
 ```
@@ -111,7 +162,8 @@ Spawn is a wrapper to NewExpect(), for compatibility with the original expect
 
 
 
-### func (\*Expect) BufStr
+
+### <a name="Expect.BufStr">func</a> (\*Expect) [BufStr](/src/target/expect.go?s=10907:10941#L388)
 ``` go
 func (exp *Expect) BufStr() string
 ```
@@ -119,7 +171,8 @@ BufStr is the buffer of expect read data as a string
 
 
 
-### func (\*Expect) Clear
+
+### <a name="Expect.Clear">func</a> (\*Expect) [Clear](/src/target/expect.go?s=10799:10825#L383)
 ``` go
 func (exp *Expect) Clear()
 ```
@@ -127,7 +180,8 @@ Clear out any unprocessed input
 
 
 
-### func (\*Expect) Expect
+
+### <a name="Expect.Expect">func</a> (\*Expect) [Expect](/src/target/expect.go?s=6888:6959#L228)
 ``` go
 func (exp *Expect) Expect(reOrStrs ...interface{}) (int, []byte, error)
 ```
@@ -141,7 +195,8 @@ See also Expecti()
 
 
 
-### func (\*Expect) Expecti
+
+### <a name="Expect.Expecti">func</a> (\*Expect) [Expecti](/src/target/expect.go?s=12342:12397#L437)
 ``` go
 func (exp *Expect) Expecti(reOrStrs ...interface{}) int
 ```
@@ -150,7 +205,8 @@ and not the found bytes or error. This is close to the original expect()
 
 
 
-### func (\*Expect) Expectp
+
+### <a name="Expect.Expectp">func</a> (\*Expect) [Expectp](/src/target/expect.go?s=12551:12606#L444)
 ``` go
 func (exp *Expect) Expectp(reOrStrs ...interface{}) int
 ```
@@ -159,15 +215,17 @@ Expectp is a convenience wrapper around Expect() that panics on no match
 
 
 
-### func (\*Expect) Kill
+
+### <a name="Expect.Kill">func</a> (\*Expect) [Kill](/src/target/expect.go?s=11045:11070#L393)
 ``` go
-func (exp *Expect) Kill() error
+func (exp *Expect) Kill()
 ```
 Kill the command. Using an Expect after a Kill is undefined
 
 
 
-### func (\*Expect) LogUser
+
+### <a name="Expect.LogUser">func</a> (\*Expect) [LogUser](/src/target/expect.go?s=12876:12911#L455)
 ``` go
 func (exp *Expect) LogUser(on bool)
 ```
@@ -177,7 +235,8 @@ For compatibility with the original expect
 
 
 
-### func (\*Expect) Send
+
+### <a name="Expect.Send">func</a> (\*Expect) [Send](/src/target/expect.go?s=11458:11504#L407)
 ``` go
 func (exp *Expect) Send(s string) (int, error)
 ```
@@ -185,7 +244,17 @@ Send sends the string to the process, for compatibility with the original expect
 
 
 
-### func (\*Expect) SendSlow
+
+### <a name="Expect.SendL">func</a> (\*Expect) [SendL](/src/target/expect.go?s=12019:12066#L426)
+``` go
+func (exp *Expect) SendL(lines ...string) error
+```
+SendL is a convenience wrapper around Send(), adding linebreaks around each of the @lines.
+
+
+
+
+### <a name="Expect.SendSlow">func</a> (\*Expect) [SendSlow](/src/target/expect.go?s=11671:11742#L413)
 ``` go
 func (exp *Expect) SendSlow(delay time.Duration, s string) (int, error)
 ```
@@ -194,7 +263,8 @@ Note: the return is the number of bytes sent not the number of runes sent
 
 
 
-### func (\*Expect) SetCmdOut
+
+### <a name="Expect.SetCmdOut">func</a> (\*Expect) [SetCmdOut](/src/target/expect.go?s=5810:5856#L200)
 ``` go
 func (exp *Expect) SetCmdOut(cmdOut io.Writer)
 ```
@@ -205,7 +275,8 @@ will not be used
 
 
 
-### func (\*Expect) SetTimeout
+
+### <a name="Expect.SetTimeout">func</a> (\*Expect) [SetTimeout](/src/target/expect.go?s=6132:6184#L212)
 ``` go
 func (exp *Expect) SetTimeout(timeout time.Duration)
 ```
@@ -214,11 +285,27 @@ The default value is zero which cause Expect() to wait forever.
 
 
 
-### func (\*Expect) SetTimeoutSecs
+
+### <a name="Expect.SetTimeoutSecs">func</a> (\*Expect) [SetTimeoutSecs](/src/target/expect.go?s=6274:6320#L217)
 ``` go
 func (exp *Expect) SetTimeoutSecs(timeout int)
 ```
 SetTimeoutSecs is a convenience wrapper around SetTimeout
+
+
+
+
+## <a name="ExpectWaitResult">type</a> [ExpectWaitResult](/src/target/expect.go?s=2885:2968#L114)
+``` go
+type ExpectWaitResult struct {
+    ProcessState *os.ProcessState
+    Error        error
+}
+```
+
+
+
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 
 # expect
-`import "github.com/leemcloughlin/expect"`
+`import "github.com/grrtrr/expect"`
 
 * [Overview](#pkg-overview)
 * [Index](#pkg-index)
@@ -22,7 +22,7 @@ line is:
 	}
 	exp.SetTimeoutSecs(5)
 	exp.Send("hello\r")
-	
+
 	// i will be the index of the argument that matched the input otherwise
 	// i will be a negative number showing match fail or error
 	i, found, err := exp.Expect("olleh")
@@ -65,7 +65,7 @@ This package has only been tested on Linux
 * [Expect (OwnEcho)](#example_Expect_ownEcho)
 
 #### <a name="pkg-files">Package files</a>
-[expect.go](/src/github.com/leemcloughlin/expect/expect.go) 
+[expect.go](/src/github.com/grrtrr/expect/expect.go)
 
 
 ## <a name="pkg-constants">Constants</a>

--- a/examples/autossh.go
+++ b/examples/autossh.go
@@ -12,7 +12,7 @@ import (
 	"os/user"
 	"path"
 
-	"github.com/leemcloughlin/expect"
+	"github.com/grrtrr/expect"
 )
 
 // Name of key (in user's $HOME/.ssh directory) to exchange

--- a/examples/autossh.go
+++ b/examples/autossh.go
@@ -1,0 +1,100 @@
+//
+// Automates the ssh key exchange for password-less login on a remote system.
+//
+// Original taken from http://www.techpaste.com/2013/04/28/shell-script-automate-ssh-key-transfer-hosts-linux/
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/user"
+	"path"
+
+	"github.com/leemcloughlin/expect"
+)
+
+// Name of key (in user's $HOME/.ssh directory) to exchange
+const (
+	keyName = "id_rsa.pub"
+)
+
+func main() {
+	var remoteUser = flag.String("l", "", "Remote user to use (defaults to local user)")
+	var password = flag.String("p", "", "Password for remote user")
+	var verbose = flag.Bool("v", true, "Log user interaction to stdout")
+
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "usage: %s [options] <remoteHost>\n", path.Base(os.Args[0]))
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+
+	if flag.NArg() != 1 || *password == "" {
+		flag.Usage()
+		os.Exit(1)
+	}
+	host := flag.Arg(0)
+
+	user, err := user.Current()
+	if err != nil {
+		log.Fatalf("failed to look up current user: %s", err)
+	}
+
+	if *remoteUser == "" {
+		*remoteUser = user.Username
+	}
+
+	keyPath := path.Join(user.HomeDir, ".ssh", keyName)
+	if _, err := os.Stat(keyPath); err != nil {
+		log.Fatalf("Can not use ssh key %s: %s", keyPath, err)
+	}
+
+	// First remove existing entries for @host from ~/.ssh/known_hosts
+	exp, err := expect.Spawn("ssh-keygen", "-R", host)
+	if err != nil {
+		log.Fatalf("failed to remove existing hostkeys for %s: %s", host, err)
+	}
+	exp.LogUser(*verbose)
+
+	_, _, err = exp.Expect("known_hosts: No such file or directory", "Original contents retained")
+	if err != nil {
+		log.Fatalf("unexpected interaction removing %s from known_hosts: %s", host, err)
+	}
+	exp.Kill()
+
+	exp, err = expect.Spawn("ssh-copy-id", "-i", keyPath, fmt.Sprintf("%s@%s", *remoteUser, host))
+	if err != nil {
+		log.Fatalf("filed to run ssh-copy-id: %s", err)
+	}
+	exp.LogUser(*verbose)
+
+	// We have removed the known_hosts key, so it will prompt to add it back again
+	exp.Expect("(yes/no)?")
+	exp.SendL("yes")
+
+	for {
+		i, _, err := exp.Expect(
+			"assword:",                    // standard password prompt
+			"Permission denied",           // password received, but incorrect
+			"already exist on the remote", // key already exists
+			"Now try",                     // issued after transfer
+		)
+		if err != nil {
+			log.Fatalf("expect error: %s", err)
+		} else if i == 3 {
+			log.Printf("Successfully transferred ssh key for %s@%s", *remoteUser, host)
+			break
+		} else if i == 2 {
+			log.Printf("Key for %s already exists on %s", *remoteUser, host)
+			break
+		} else if i == 1 {
+			log.Fatalf("Wrong password (permission denied) for %s@%s", *remoteUser, host)
+		} else if i == 0 {
+			exp.SendL(*password)
+		} else {
+			log.Fatalf("unexpected response - try -v to debug")
+		}
+	}
+}

--- a/examples/delete_mail.go
+++ b/examples/delete_mail.go
@@ -1,0 +1,36 @@
+// Delete all system mails of the current user, like 'yes d | mail'
+// Please use with care :-)
+package main
+
+import (
+	"log"
+
+	"github.com/leemcloughlin/expect"
+)
+
+func main() {
+	exp, err := expect.Spawn("mail")
+	if err != nil {
+		log.Fatalf("failed to spawn mail program: %s", err)
+	}
+	exp.LogUser(true)
+
+	for {
+		// '&' is the mail user prompt
+		i, _, err := exp.Expect("No mail", "& ", "No applicable messages")
+		if err != nil {
+			log.Fatalf("failed to match expressed expressions: %s", err)
+		}
+
+		if i == 0 { // Nothing to delete
+			break
+		} else if i == 1 { // prompt
+			exp.SendL("d")
+		} else if i == 2 { // no applicable messages - everything deleted
+			exp.SendL("q")
+			break
+		} else if i == expect.NotFound {
+			log.Fatalf("program closed unexpectedly")
+		}
+	}
+}

--- a/examples/delete_mail.go
+++ b/examples/delete_mail.go
@@ -5,7 +5,7 @@ package main
 import (
 	"log"
 
-	"github.com/leemcloughlin/expect"
+	"github.com/grrtrr/expect"
 )
 
 func main() {

--- a/examples/ftp.go
+++ b/examples/ftp.go
@@ -1,0 +1,30 @@
+// ftp example thanks to github.com/ThomasRooney/gexpect
+package main
+
+import (
+	"log"
+
+	"github.com/leemcloughlin/expect"
+)
+
+func main() {
+	exp, err := expect.Spawn("ftp", "openbsd.cs.toronto.edu")
+	if err != nil {
+		log.Fatalf("failed to spawn OpenBSD ftp: %s", err)
+	}
+	exp.LogUser(true)
+
+	exp.Expect("Name")
+	exp.SendL("anonymous")
+	exp.Expect("Password")
+	exp.SendL("expect@sourceforge.net")
+	exp.Expect("ftp> ")
+	exp.SendL("cd /pub/OpenBSD/5.8")
+	exp.Expect("ftp> ")
+	exp.SendL("dir")
+	exp.Expect("ftp> ")
+	exp.SendL("prompt")
+	exp.Expect("ftp> ")
+	exp.SendL("pwd")
+	exp.Expect("ftp> ")
+}

--- a/examples/ftp.go
+++ b/examples/ftp.go
@@ -4,7 +4,7 @@ package main
 import (
 	"log"
 
-	"github.com/leemcloughlin/expect"
+	"github.com/grrtrr/expect"
 )
 
 func main() {

--- a/examples/olleh.go
+++ b/examples/olleh.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/leemcloughlin/expect"
+	"github.com/grrtrr/expect"
 )
 
 func main() {

--- a/examples/olleh.go
+++ b/examples/olleh.go
@@ -1,0 +1,26 @@
+// Classical !dlrow olleh example
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/leemcloughlin/expect"
+)
+
+func main() {
+	exp, err := expect.NewExpect("rev")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "NewExpect failed %s", err)
+	}
+	exp.SetTimeoutSecs(5) // Shouldn't happen
+	exp.Send("hello\r")
+
+	i, found, err := exp.Expect("olleh")
+	if i == 0 {
+		fmt.Println("found", string(found))
+	} else {
+		fmt.Println("failed ", err)
+	}
+	exp.Kill()
+}

--- a/examples/python.go
+++ b/examples/python.go
@@ -1,0 +1,20 @@
+// Interact with the Python interpreter using go expect.
+package main
+
+import (
+	"log"
+
+	"github.com/leemcloughlin/expect"
+)
+
+func main() {
+	exp, err := expect.Spawn("python")
+	if err != nil {
+		log.Fatalf("Failed to spawn python process: %s", err)
+	}
+	exp.LogUser(true)
+
+	exp.Expect(">>>")
+	exp.SendL("import time", "print 'It is now %s' % time.ctime(time.time())", "exit()")
+	exp.Expect("exit()")
+}

--- a/examples/python.go
+++ b/examples/python.go
@@ -4,7 +4,7 @@ package main
 import (
 	"log"
 
-	"github.com/leemcloughlin/expect"
+	"github.com/grrtrr/expect"
 )
 
 func main() {

--- a/expect.go
+++ b/expect.go
@@ -373,7 +373,7 @@ func (exp *Expect) expectReader() {
 			return
 		default:
 			n, err := exp.cmdIn.Read(buf)
-			debugf("expectReader read %d, %c, %s", n, buf[0], err)
+			debugf("expectReader read %d, %c, %v", n, buf[0], err)
 			if err != nil {
 				if unixIsEAGAIN(err) {
 					debugf("expectReader EAGAIN")

--- a/expect.go
+++ b/expect.go
@@ -130,11 +130,9 @@ type ExpectWaitResult struct {
 
 // debugf logs only if Debug is true
 func debugf(format string, args ...interface{}) {
-	if !Debug {
-		return
+	if Debug {
+		log.Printf(format, args...)
 	}
-	s := fmt.Sprintf(format, args...)
-	log.Print(s)
 }
 
 // NewExpect starts prog, passing any given args, in its own pty.

--- a/expect.go
+++ b/expect.go
@@ -448,6 +448,16 @@ func (exp *Expect) SendSlow(delay time.Duration, s string) (int, error) {
 	return len([]byte(s)), nil
 }
 
+// SendL is a convenience wrapper around Send(), adding linebreaks around each of the @lines.
+func (exp *Expect) SendL(lines ...string) error {
+	for _, line := range lines {
+		if _, err := exp.Send(line + "\r"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Expecti is a convenience wrapper around Expect() that only returns the index
 // and not the found bytes or error. This is close to the original expect()
 func (exp *Expect) Expecti(reOrStrs ...interface{}) int {

--- a/expect.go
+++ b/expect.go
@@ -124,9 +124,6 @@ type Expect struct {
 }
 
 type ExpectWaitResult struct {
-	// IsValid is true if this has been set because wait returned
-	IsValid bool
-
 	ProcessState *os.ProcessState
 	Error        error
 }
@@ -212,7 +209,6 @@ func newExpectCommon(reap bool, prog string, arg ...string) (*Expect, error) {
 // Wait() result
 func (exp *Expect) expectReaper() {
 	exp.Result.ProcessState, exp.Result.Error = exp.cmd.Process.Wait()
-	exp.Result.IsValid = true
 }
 
 // SetCmdOut if a non-nil io.Writer is passed it will be sent a copy of everything

--- a/expect.go
+++ b/expect.go
@@ -156,6 +156,9 @@ func NewExpect(prog string, arg ...string) (*Expect, error) {
 // Note that Result is not filled in.
 func NewExpectProc(prog string, arg ...string) (*Expect, *exec.Cmd, error) {
 	exp, err := newExpectCommon(false, prog, arg...)
+	if err != nil {
+		return nil, nil, err
+	}
 	return exp, exp.cmd, err
 }
 

--- a/expect.go
+++ b/expect.go
@@ -169,11 +169,6 @@ func newExpectCommon(reap bool, prog string, arg ...string) (*Expect, error) {
 	exp := new(Expect)
 	exp.cmd = exec.Command(prog, arg...)
 	exp.File, err = pty.Start(exp.cmd)
-
-	if reap && exp.cmd.Process != nil {
-		go exp.expectReaper()
-	}
-
 	if err != nil {
 		if exp.cmd.Process != nil {
 			if err2 := exp.cmd.Process.Kill(); err2 != nil {
@@ -201,6 +196,9 @@ func newExpectCommon(reap bool, prog string, arg ...string) (*Expect, error) {
 	exp.endExpectReader = make(chan bool, 2) // should be 1 but just in case have extra space
 	exp.expectReaderRunning = true
 	go exp.expectReader()
+	if reap {
+		go exp.expectReaper()
+	}
 
 	return exp, err
 }

--- a/expect_linux.go
+++ b/expect_linux.go
@@ -1,0 +1,58 @@
+// +build linux
+
+package expect
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"syscall"
+
+	"github.com/kr/pty"
+)
+
+const (
+	// EOF is the terminal EOF character - NOT guaranteed to be correct on all
+	// systems nor if the program passed to expect connects to a different
+	// platform
+	EOF = "\004"
+)
+
+// newExpectCommon uses @parentCtx as cancellation context and @reap to indicate
+// whether the spawned process should automatically be reaped.
+func newExpectCommon(parentCtx context.Context, reap bool, prog string, arg ...string) (exp *Expect, err error) {
+	defer func() {
+		// On an error I want to kill the process - if it was started
+		if err != nil && exp != nil && exp.cmd.Process != nil {
+			debugf("killing process %q due to error (%s)", prog, err)
+			exp.Kill()
+		}
+	}()
+
+	exp = &Expect{
+		Buffer:  new(bytes.Buffer),
+		bytesIn: make(chan byteIn, ExpectInSize),
+	}
+
+	// Create a cancelable child context for exp.cmd (go >= 1.7)
+	exp.ctx, exp.cancel = context.WithCancel(parentCtx)
+	exp.cmd = exec.CommandContext(exp.ctx, prog, arg...)
+
+	if exp.file, err = pty.Start(exp.cmd); err != nil {
+		return nil, err
+	}
+
+	// make the pty non blocking so when I read from it I dont jam up
+	if err = syscall.SetNonblock(int(exp.file.Fd()), true); err != nil {
+		return nil, err
+	}
+	exp.SetCmdOut(nil)
+
+	go exp.expectReader()
+
+	if reap {
+		go exp.expectReaper()
+	}
+
+	return exp, nil
+}

--- a/expect_test.go
+++ b/expect_test.go
@@ -14,6 +14,7 @@ package expect
 
 import (
 	"bytes"
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -128,7 +129,7 @@ func Test_NewExpectProc(t *testing.T) {
 	defer debugf("%s end", funcName())
 
 	t.Logf("starting %s", prog)
-	exp, cmd, err := NewExpectProc(prog)
+	exp, cmd, err := NewExpectProc(context.TODO(), prog)
 	if err != nil {
 		t.Errorf("NewExpect failed %s", err)
 		return

--- a/expect_test.go
+++ b/expect_test.go
@@ -90,7 +90,7 @@ func showWaitResult(t *testing.T, exp *Expect) {
 	// but checking for all the errors is painful for code I expect to be used
 	// so rarely)
 	for i := 1; i <= 3; i++ {
-		if exp.Result.IsValid {
+		if exp.Result.ProcessState != nil || exp.Result.Error != nil {
 			valid = true
 			break
 		}

--- a/expect_windows.go
+++ b/expect_windows.go
@@ -1,0 +1,18 @@
+// +build windows
+
+package expect
+
+import (
+	"context"
+	"errors"
+)
+
+const (
+	// No good way to discover EOF so have to take a best guess
+	// Default (above) to control-D
+	EOF = "\032" // control-Z
+)
+
+func newExpectCommon(parentCtx context.Context, reap bool, prog string, arg ...string) (exp *Expect, err error) {
+	return nil, errors.New("expect is not yet implemented on Windows - sorry")
+}

--- a/rebuildREADME
+++ b/rebuildREADME
@@ -1,2 +1,2 @@
 #!/bin/sh
-godoc2md github.com/leemcloughlin/expect > README.md
+godoc2md github.com/grrtrr/expect > README.md


### PR DESCRIPTION
This contains a few self-contained executable examples which have helped me to better understand the use of the API.

Also contained is a `SendL(lines ...string)` convenience function, to add (a) terminating newline, (b) allow to send multiple input lines in one single batch.